### PR TITLE
fix 167: Update engagement_and_scoping to fit structure

### DIFF
--- a/engagement_and_scoping.qmd
+++ b/engagement_and_scoping.qmd
@@ -7,54 +7,69 @@ The draft currently has no official status. It is a work in progress and is subj
 # Engagement and scoping
 
 ## Introduction
-The first stage of the analytical cycle is initial customer engagement and scoping identifying what the Commissioner requires and so what is relevant for the analysis.  The Analyst works with the  Commissioner to develop sufficient understanding of the problem to design a requisite analysis.
+The first stage of the analytical lifecycle is initial engagement and scoping  what the Commissioner requires. This information constrains what is relevant for the analysis.  The Analyst works with the  Commissioner to develop sufficient understanding of the problem to design a requisite analysis.
 
 During engagement and scoping, the Commissioner and the Analyst shape the analysis by developing a shared understanding of the problem and the context. This shared understanding will be used as the basis for designing analysis that suits the Commissioner’s requirements.
 
-### The Commissioner's responsibilities during engagement and scoping
+### The Commissioner's responsibilities during the engagement and scoping stage
 
-The Commissioner is responsible for ensuring that:
+The Commissioner:
 
-* Communicating to the Analyst the key aspects of the problem, scope, and programme constraints.    
-* They are available to engage with the Analyst to appropriately shape the work.    
-* There is sufficient governance in place to support the analysis and its role in the wider project or programme. This is particularly important if the analysis supports business critical decisions. This  may need to be revisited at the design stage if a novel or riskier approach is required (for example if AI models are used).    
-* They understand risks where time and resource pressures constrain the approach.    
-* They communicate to the Analyst any sources of uncertainty they have identified as part of their wider considerations.    
-* [Not sure about this] They request information from the Analyst on accounting for uncertainty, and challenge them when it is absent, inadequate or ambiguous.
-* If possible, indicate the consequences for decision-making of different degrees of uncertainty, as this may enable the Analyst to conduct their analysis at a proportionate level.    
-* The specification document produced by the analyst is signed off.
+* Should communicate to the Analyst the key aspects of the problem, scope, and programme constraints.    
+* Should be available to engage with the Analyst to appropriately shape the work.
+* Must ensure that they understand risks where time and resource pressures constrain the approach. 
+* Should communicate to the Analyst any sources of uncertainty they have identified as part of their wider considerations.    
+* [Not sure about this] Should request information from the Analyst on accounting for uncertainty, and challenge them when it is absent, inadequate or ambiguous.
+* If possible, the  indicate the consequences for decision-making of different degrees of uncertainty, as this may enable the Analyst to conduct their analysis at a proportionate level.    
+* Should sign-off on the specification document produced by the analyst.
 
-### The Analyst's responsibilities during engagement and scoping
+### The Analyst's responsibilities during the engagement and scoping stage
+The Analyst:
+* Should engaging with the Commissioner to identify the question, the context, and the boundaries of the analysis, as well as constraints (e.g. deadlines, available resource), assumptions, risks, identified uncertainties and business-criticality. 
+* Should create a specification document which captures the Commissioner's requirements. It should provide a definition of the scope and project constraints. It should state the acceptable level of risk, the required level of assurance. It may also state the degree of uncertainty allowed for decision-making, and record identified sources of uncertainty. The Analyst should share this specification with the Commisioner for sign-off.
 
-* The Analyst is responsible for engaging with the Commissioner to identify the question, the context, and the boundaries of the analysis, as well as constraints (e.g. deadlines, available resource), assumptions, risks, and business-criticality. 
-* The Analyst should create a specification document which captures the iCommissioner's requirements. It should provide a definition of the scope and project constraints. It should state the acceptable level of risk, the required level of assurance. It may also state the degree of uncertainty allowed for decision-making.
-* The Analyst should share this specification with the customer and seek agreement on the approach.
+### The Assurer's responsibilities during the engagement and scoping stage
 
-### The Assurer's responsibilities during engagement and scoping
+The Assurer might confirm that the engagement process has been sufficient to fully understand the problem. For more business critical projects, they might wish to confirm that the specification document adequately captures the outcomes of the engagement process.
 
-The Assurer should confirm that the engagement process has been sufficient to fully understand the problem, and that the specification document adequately captures the outcomes of the engagement process.
+### The Approver's responsibilities during the engagement and scoping stage
 
-### The Approver's responsibilities during engagement and scoping
+The Approver may note the new project, confirm that resources and plans are in place for the appropriate assurance to take place. For example, they should ensure that the Analyst and Assurer are aware of local assurance protocols.  
 
-The Approver may note the new projectm, confirm that resources and plans are in place for the appropriate assurance to take place. For example, they should ensure that the Analyst and Assurer are aware of local assurance protocols. 
+The Approver should ensure that there is sufficient governance in place to support the analysis and their role in the wider project or programme. This is particularly important if the analysis supports business critical decisions. This  may need to be revisited at the design stage if a novel or riskier approach is required (for example if AI models are used).
 
 ## Assurance of the engagement and scoping stage
 
-The engagement and scoping stage provides the Analyst with an understanding of the Commissioner's requirements. In some cases, the Commissioner may present a well-defined problem, while in other instances, the engagement stage may require problem structuring methods. Techniques such as the Strategic Choice Approach, Rich Pictures and Systems Thinking can help the Analyst and Commissioner to reach a joint understanding of the problem (see the [Systems Thinking Toolkit](https://www.gov.uk/government/publications/systems-thinking-for-civil-servants/toolkit) for further information). Through the engagement, the Analyst and Commissioner will be in a position to define the scope of the project in terms of the context and bounds of the analysis. In cases where the engagement and scoping techniques are complex and/or the project is deemed business critical, the Assurer might provide assurance of the engagement methodology (https://publications.tno.nl/publication/100301/Zs2SUz/wijnmalen-2012-natoclient.pdf)
+The engagement and scoping stage provides the Analyst with an understanding of the Commissioner's requirements. In some cases, the Commissioner may present a well-defined problem, while in other instances, the engagement stage may require problem structuring methods. Techniques such as the Strategic Choice Approach, Rich Pictures and Systems Thinking can help the Analyst and Commissioner to reach a joint understanding of the problem (see the [Systems Thinking Toolkit](https://www.gov.uk/government/publications/systems-thinking-for-civil-servants/toolkit) for further information). The engagement will lead to the Analyst and Commissioner being able to define the scope of the project in terms of the context and bounds of the analysis. In cases where the engagement and scoping techniques are complex and/or the project is deemed business critical, the Assurer might provide assurance of the engagement methodology (https://publications.tno.nl/publication/100301/Zs2SUz/wijnmalen-2012-natoclient.pdf)
 
-In addition to understanding the problem, the engagement and scoping stage should lead to agreement between the Analyst and Commissioner about the outputs to be delivered, including acceptable levels of accuracy, precision and margins of error. This will inform the handling of uncertainty and the assurance of thereof in later stages.
+In addition to understanding the problem, the engagement and scoping stage should lead to agreement between the Analyst and Commissioner about the outputs to be delivered, including acceptable levels of accuracy, precision and margins of error. This will inform the handling of uncertainty and the assurance thereof in later stages.
 
 
 The Analyst and Commissioner should also clarify risks and potential impacts of the project which will inform the decisions around [proportionate assurance](proportionality.qmd). Constraints around resource and timelines should also be clarified and agreed.
 
-The output of this phase should be a [specfication document](Add hyperlink) that captures the joint understanding. This document provides a reference for later [validation](#def_validation) assurance activities (i.e. that the analysis meets the specification). This document also provides evidence for the Approver during the [delivery stage](delivery_and_communication.qmd) that the analysis meets the specification. The document should be signed off by the Commissioner, and might be reviewed by the Assurer.
+## Documenting the engagement and scoping stage
+
+The output of this phase should be a [specfication document](Add hyperlink) that captures the joint understanding. This document provides a reference for later [validation](definitions.qmd/#def_validation) assurance activities (i.e. that the analysis meets the specification). This document also provides evidence for the Approver during the [delivery stage](delivery_and_communication.qmd) that the analysis meets the specification. The document should be signed off by the Commissioner, and might be reviewed by the Assurer.
+
+## Treatment of uncertainty in the engagement and scoping stage
+
+The following aspects of the engagement and scoping stage will inform the treatment of uncertainty:
+* A clear definition of the analytical question
+* Identification of sources of high and/or intractable uncertainty
+* Establishing an understanding of how the analyis will inform decisions
+
+Futher details on Uncertainty in engagement and scoping can be found in the [Uncertainty Toolkit](https://analystsuncertaintytoolkit.github.io/UncertaintyWeb/chapter_2.html#Jointly_agreeing_how_uncertainty_should_be_used)
+
+## AI/ML and the engagement and scoping stage
+
+Where the Commissioner has engaged with the Analyst to deliver AI/ML models, the engagement and scoping stage should include discussions around ethics and risks in order to assess whether such models would be appropriate for addressing the given problem. For example, discussions might include considerations of regulations such as UK GDPR, organisational skills, and internal governance and risk management. For further details see https://www.gov.uk/government/publications/introduction-to-ai-assurance/introduction-to-ai-assurance.
 
 ## Multi-use models and the engagement and scoping stage
 
 In the case of multi-use models, the Analyst may be required to engage with a group of end-users to develop an understanding of their respective requirements. As requirements might differ or contradict, techniques such as Strategic Options Development and Analysis ([SODA](https://www.ru.nl/publish/pages/938444/soda_-_the_principles.pdf)) and [Soft Systems Methodology]**ADD HYPERLINK** may be used to develop a shared understanding across multiple groups.
 
-## Black-box models and the engagement and scoping stage
 
-Where the Commissioner has engaged with the Analyst to deliver AI/ML models, the engagement and scoping stage should include discussions around ethics and risks in order to assess whether such models would be appropriate for addressing the given problem. For example, discussions might include considerations of regulations such as UK GDPR, organisational skills, and internal governance and risk management. For further details see https://www.gov.uk/government/publications/introduction-to-ai-assurance/introduction-to-ai-assurance.
+## Engagement and scoping when working with third-parties
 
+TBC
 

--- a/engagement_and_scoping.qmd
+++ b/engagement_and_scoping.qmd
@@ -44,6 +44,8 @@ The engagement and scoping stage provides the Analyst with an understanding of t
 
 In addition to understanding the problem, the engagement and scoping stage should lead to agreement between the Analyst and Commissioner about the outputs to be delivered, including acceptable levels of accuracy, precision and margins of error. This will inform the handling of uncertainty and the assurance thereof in later stages.
 
+The Commissioner should communicate to the Analyst what is known about data sources and data quality. This will be used to guide the design of data processing.
+
 
 The Analyst and Commissioner should also clarify risks and potential impacts of the project which will inform the decisions around [proportionate assurance](proportionality.qmd). Constraints around resource and timelines should also be clarified and agreed.
 


### PR DESCRIPTION
New structure: 

• Intro & Summary
o Responsibility by role
• Assurance activities (include paragraph on Data and assurance)
• Documentation
• Uncertainty
• AI/ML
• Multi-use models
• Working with third parties
• Other sections that are relevant to the chapter
----

Commissioner responsibility changed to Approver  "The Approver should ensure that there is sufficient governance in place to support the analysis and their role in the wider project or programme. This is particularly important if the analysis supports business critical decisions. This  may need to be revisited at the design stage if a novel or riskier approach is required (for example if AI models are used)."

Responsilbilities changed to use imperative keywords